### PR TITLE
Fixes unit tests

### DIFF
--- a/bufrtools/tests/encoding/test_wildlife_computers.py
+++ b/bufrtools/tests/encoding/test_wildlife_computers.py
@@ -59,7 +59,7 @@ def test_wildlife_computers_encoding_from_netcdf(parse_args, tempfile_fixture):
 
         # Verify that there are 157 profiles
         f.seek(1862)
-        assert f.read(2) == b'\x3F\x3A'
+        assert f.read(2) == b'\xBF\x3A'
 
 
 @patch('bufrtools.encoding.wildlife_computers.parse_args')
@@ -90,7 +90,7 @@ def test_wildlife_computers_encoding_from_parquet(parse_args, tempfile_fixture):
 
         # Verify that there are 157 profiles
         f.seek(1862)
-        assert f.read(2) == b'\x3F\x3A'
+        assert f.read(2) == b'\xBF\x3A'
 
 
 @patch('bufrtools.encoding.wildlife_computers.parse_args')
@@ -121,4 +121,4 @@ def test_wildlife_computers_encoding_from_csv(parse_args, tempfile_fixture):
 
         # Verify that there are 157 profiles
         f.seek(1862)
-        assert f.read(2) == b'\x3F\x3A'
+        assert f.read(2) == b'\xBF\x3A'


### PR DESCRIPTION
A while back when we made the change of units from deg_C to Kelvin for
temperature values, the temperature field overlapped with the same octet
that described the replication factor (i.e. number of profiles to
follow) which broke the tests. This commit updates the expected value to
match what it should be. In the MR I will include screenshots of the
hexdump for confirmation.

![image](https://user-images.githubusercontent.com/1155163/156561603-16873342-8049-4374-981e-012b210ce9ea.png)

![image](https://user-images.githubusercontent.com/1155163/156561639-50601a3f-01c7-4eb6-a799-98196cffc276.png)
