### PR TITLE
Updates README with a specific example and adds setuptools

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ Usage:
 python bufrtools/encoding/wildlife_computers.py -o <output bufr file> <netCDF path>
 ```
 
+Example to produce bufr message for the netCDF file in the examples folder:
+```
+python bufrtools/encoding/wildlife_computers.py -o examples/profile-example.bufr examples/profile.nc
+```
+
+We can see that the file is a BUFR file by inspecting the first 4 bytes:
+
+```
+hexdump -C -n4 examples/output.bufr
+00000000  42 55 46 52                                       |BUFR|
+00000004
+```
+
 The following table contains the expanded sequence of descriptors for temperature salinity profiles and trajectories originating from marine animal tags.
 
 The source of this information is the published [Manual on WMO Codes](https://library.wmo.int/doc_num.php?explnum_id=10722).

--- a/environment.yml
+++ b/environment.yml
@@ -9,3 +9,4 @@ dependencies:
   - pandas
   - pocean-core>=1.9.3
   - pyarrow
+  - setuptools


### PR DESCRIPTION
Python moves fast, and if we're not careful we could miss it. In this case pkg_resources is no longer a part of our default environment, so we must explicitly include setuptools to ensure that pkg_resources is available.