### PR TITLE
Fix CI Action

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,13 +12,15 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
+      with:
+        python-version: 3.x
     - uses: pre-commit/action@v2.0.0
 
   test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10", "3.12"]
         os: [ubuntu-latest]
 
     steps:
@@ -56,7 +58,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.x
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,6 @@ repos:
         - requirements.txt
 
 - repo: https://github.com/pycqa/flake8
-  rev: 4.0.1
+  rev: 7.1.1
   hooks:
     - id: flake8

--- a/bufrtools/encoding/wildlife_computers.py
+++ b/bufrtools/encoding/wildlife_computers.py
@@ -61,14 +61,14 @@ def drift(df: pd.DataFrame) -> np.ndarray:
     travel no distance over no time will have a drift of zero. The last element of the returned
     array will be 0, as it can not be effectively calculated.
     """
-    # Convert to epoch seconds
-    t = df.groupby('profile')['time'].first().view('int64') // 1e9
-    dt = np.diff(t)
+    t = df.groupby('profile')['time'].first()
+    # Calculate time differences and convert to seconds
+    dt = np.diff(t).astype('timedelta64[s]').view('int64')
 
     x = df.groupby('profile')['lon'].first() * np.pi / 180
     y = df.groupby('profile')['lat'].first() * np.pi / 180
     ds = haversine_distance(x.values, y.values)
-    ds_dt = np.zeros_like(t)
+    ds_dt = np.zeros_like(t.view('float64'))
     for i in range(ds.shape[0]):
         if np.abs(ds[i]) < 0.0001 and np.abs(dt[i]) < 0.0001:
             ds_dt[i] = 0

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - pre-commit
   - flake8
   - flake8-docstrings
   - pytest


### PR DESCRIPTION
https://axds.atlassian.net/browse/ATN-717

- fix `flake8` dependency issue by updating it's version in `pre-commit` config
- fix tests failing because of attempted `int(math.inf)` in `bufr.py`
  - ~~not sure if this is actually a good behavior: I cap the number to `sys.maxsize` before conversion to int~~
  - `inf` is introduced when calculating drift and distance > 0 and time delta = 0 (on [encoding/wildlife_computers.py:76](https://github.com/axiom-data-science/bufrtools/blob/1853189f00a8f6b0f7d08a0f961d69621a91a7fc/bufrtools/encoding/wildlife_computers.py#L76))
    - ~~maybe replacing `inf` with `nan` right at the source would be better? I don't know the usage context so I'm not sure.~~
    - turns out there is a deeper cause described in a comment below